### PR TITLE
Update CI Python version

### DIFF
--- a/.github/workflows/periodic-ci.yaml
+++ b/.github/workflows/periodic-ci.yaml
@@ -17,7 +17,8 @@ jobs:
     strategy:
       matrix:
         python:
-          - "3.11"
+          - "3.12"
+          - "3.13"
 
     steps:
       - uses: actions/checkout@v4
@@ -27,7 +28,7 @@ jobs:
       # how dependencies should later be updated.
       - uses: lsst-sqre/run-neophile@v1
         with:
-          python-version: "3.11"
+          python-version: "3.12"
           mode: update
 
       - uses: lsst-sqre/run-tox@v1


### PR DESCRIPTION
Update the version of Python used for periodic CI tests to 3.12 (with a test matrix for 3.13 as well). The package no longer installs with Python 3.11.